### PR TITLE
연간일정 API 추가

### DIFF
--- a/escahp/src/main/java/com/esca/escahp/schedule/I_ScheduleService.java
+++ b/escahp/src/main/java/com/esca/escahp/schedule/I_ScheduleService.java
@@ -1,4 +1,5 @@
 package com.esca.escahp.schedule;
 
 public interface I_ScheduleService {
+
 }

--- a/escahp/src/main/java/com/esca/escahp/schedule/I_ScheduleService.java
+++ b/escahp/src/main/java/com/esca/escahp/schedule/I_ScheduleService.java
@@ -1,5 +1,20 @@
 package com.esca.escahp.schedule;
 
+import com.esca.escahp.schedule.dto.ScheduleRequest;
+import com.esca.escahp.schedule.dto.ScheduleResponse;
+
+import java.util.List;
+
 public interface I_ScheduleService {
+
+    List<ScheduleResponse> getScheduleList();
+
+    ScheduleResponse selectSchedule(long id);
+
+    ScheduleResponse addSchedule(ScheduleRequest request);
+
+    ScheduleResponse updateSchedule(long id, ScheduleRequest request);
+
+    void deleteSchedule(long id);
 
 }

--- a/escahp/src/main/java/com/esca/escahp/schedule/ScheduleController.java
+++ b/escahp/src/main/java/com/esca/escahp/schedule/ScheduleController.java
@@ -1,8 +1,47 @@
 package com.esca.escahp.schedule;
 
-
-import org.springframework.web.bind.annotation.RestController;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/schedules")
+@CrossOrigin(origins = {"*"})
 public class ScheduleController {
+
+    private final I_ScheduleService scheduleService;
+
+    public ScheduleController(I_ScheduleService scheduleService) {
+        this.scheduleService = scheduleService;
+    }
+
+    @ApiOperation(value = "전체 연간일정 조회")
+    @GetMapping()
+    public void getAllSchedules() {
+        return;
+    }
+
+    @ApiOperation(value = "특정 연간일정 상세 정보 조회")
+    @GetMapping("/{id}")
+    public void getSchedule(@PathVariable long id) {
+        return;
+    }
+
+    @ApiOperation(value = "연간일정 등록")
+    @PostMapping
+    public void insertSchedule() {
+        return;
+    }
+
+    @ApiOperation(value = "연간일정 수정")
+    @PutMapping("/{id}")
+    public void updateSchedule() {
+        return;
+    }
+
+    @ApiOperation(value = "연간일정 삭제")
+    @DeleteMapping("/{id}")
+    public void deleteSchedule() {
+        return;
+    }
+
 }

--- a/escahp/src/main/java/com/esca/escahp/schedule/ScheduleController.java
+++ b/escahp/src/main/java/com/esca/escahp/schedule/ScheduleController.java
@@ -1,7 +1,14 @@
 package com.esca.escahp.schedule;
 
+import com.esca.escahp.schedule.dto.ScheduleRequest;
+import com.esca.escahp.schedule.dto.ScheduleResponse;
 import io.swagger.annotations.ApiOperation;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/schedules")
@@ -16,32 +23,41 @@ public class ScheduleController {
 
     @ApiOperation(value = "전체 연간일정 조회")
     @GetMapping()
-    public void getAllSchedules() {
-        return;
+    public ResponseEntity<List<ScheduleResponse>> getAllSchedules() {
+        List<ScheduleResponse> responses = scheduleService.getScheduleList();
+        return ResponseEntity.ok(responses);
     }
 
     @ApiOperation(value = "특정 연간일정 상세 정보 조회")
     @GetMapping("/{id}")
-    public void getSchedule(@PathVariable long id) {
-        return;
+    public ResponseEntity<ScheduleResponse> getSchedule(@PathVariable Long id) {
+        ScheduleResponse response = scheduleService.selectSchedule(id);
+        return ResponseEntity.ok(response);
     }
 
     @ApiOperation(value = "연간일정 등록")
     @PostMapping
-    public void insertSchedule() {
-        return;
+    public ResponseEntity<ScheduleResponse> insertSchedule(@RequestBody ScheduleRequest request) {
+        ScheduleResponse response = scheduleService.addSchedule(request);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(response.getId())
+                .toUri();
+        return ResponseEntity.created(location).build();
     }
 
     @ApiOperation(value = "연간일정 수정")
     @PutMapping("/{id}")
-    public void updateSchedule() {
-        return;
+    public ResponseEntity<ScheduleResponse> updateSchedule(@PathVariable Long id, @RequestBody ScheduleRequest request) {
+        ScheduleResponse response = scheduleService.updateSchedule(id, request);
+        return ResponseEntity.ok(response);
     }
 
     @ApiOperation(value = "연간일정 삭제")
     @DeleteMapping("/{id}")
-    public void deleteSchedule() {
-        return;
+    public ResponseEntity<Void> deleteSchedule(@PathVariable Long id) {
+        scheduleService.deleteSchedule(id);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/escahp/src/main/java/com/esca/escahp/schedule/ScheduleService.java
+++ b/escahp/src/main/java/com/esca/escahp/schedule/ScheduleService.java
@@ -1,7 +1,14 @@
 package com.esca.escahp.schedule;
 
+import com.esca.escahp.schedule.dto.ScheduleRequest;
+import com.esca.escahp.schedule.dto.ScheduleResponse;
+import com.esca.escahp.schedule.entity.Schedule;
 import com.esca.escahp.schedule.repository.ScheduleRepository;
 import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class ScheduleService implements I_ScheduleService {
@@ -10,5 +17,45 @@ public class ScheduleService implements I_ScheduleService {
 
     public ScheduleService(ScheduleRepository scheduleRepository) {
         this.scheduleRepository = scheduleRepository;
+    }
+
+
+    @Override
+    public List<ScheduleResponse> getScheduleList() {
+        List<Schedule> schedules = scheduleRepository.findAll();
+        return schedules.stream().map(ScheduleResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public ScheduleResponse selectSchedule(long id) {
+        Schedule schedule = scheduleRepository.findById(id)
+                .orElseThrow();
+        return new ScheduleResponse(schedule);
+    }
+
+    @Transactional
+    @Override
+    public ScheduleResponse addSchedule(ScheduleRequest request) {
+        Schedule schedule = new Schedule(request.getTitle(), request.getTag(), request.getContent(), request.getStartDate(), request.getStartDate());
+        Schedule savedSchedule = scheduleRepository.save(schedule);
+        return new ScheduleResponse(schedule);
+    }
+
+    @Transactional
+    @Override
+    public ScheduleResponse updateSchedule(long id, ScheduleRequest request) {
+        Schedule schedule = scheduleRepository.findById(id)
+                .orElseThrow();;
+        schedule.update(request.getTitle(), request.getTag(), request.getContent(), request.getStartDate(), request.getEndDate());
+        return new ScheduleResponse(schedule);
+    }
+
+    @Transactional
+    @Override
+    public void deleteSchedule(long id) {
+        scheduleRepository.findById(id)
+                .orElseThrow();
+        scheduleRepository.deleteById(id);
     }
 }

--- a/escahp/src/main/java/com/esca/escahp/schedule/ScheduleService.java
+++ b/escahp/src/main/java/com/esca/escahp/schedule/ScheduleService.java
@@ -38,7 +38,7 @@ public class ScheduleService implements I_ScheduleService {
     @Transactional
     @Override
     public ScheduleResponse addSchedule(ScheduleRequest request) {
-        Schedule schedule = new Schedule(request.getTitle(), request.getTag(), request.getContent(), request.getStartDate(), request.getStartDate());
+        Schedule schedule = new Schedule(request.getTitle(), request.getTag(), request.getContent(), request.getStartDate(), request.getEndDate());
         Schedule savedSchedule = scheduleRepository.save(schedule);
         return new ScheduleResponse(savedSchedule);
     }

--- a/escahp/src/main/java/com/esca/escahp/schedule/ScheduleService.java
+++ b/escahp/src/main/java/com/esca/escahp/schedule/ScheduleService.java
@@ -1,7 +1,14 @@
 package com.esca.escahp.schedule;
 
+import com.esca.escahp.schedule.repository.ScheduleRepository;
 import org.springframework.stereotype.Service;
 
 @Service
-public class ScheduleService {
+public class ScheduleService implements I_ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+
+    public ScheduleService(ScheduleRepository scheduleRepository) {
+        this.scheduleRepository = scheduleRepository;
+    }
 }

--- a/escahp/src/main/java/com/esca/escahp/schedule/ScheduleService.java
+++ b/escahp/src/main/java/com/esca/escahp/schedule/ScheduleService.java
@@ -1,8 +1,10 @@
 package com.esca.escahp.schedule;
 
+import com.esca.escahp.exception.EscaException;
 import com.esca.escahp.schedule.dto.ScheduleRequest;
 import com.esca.escahp.schedule.dto.ScheduleResponse;
 import com.esca.escahp.schedule.entity.Schedule;
+import com.esca.escahp.schedule.exceptions.ScheduleExceptions;
 import com.esca.escahp.schedule.repository.ScheduleRepository;
 import org.springframework.stereotype.Service;
 
@@ -19,7 +21,6 @@ public class ScheduleService implements I_ScheduleService {
         this.scheduleRepository = scheduleRepository;
     }
 
-
     @Override
     public List<ScheduleResponse> getScheduleList() {
         List<Schedule> schedules = scheduleRepository.findAll();
@@ -30,7 +31,7 @@ public class ScheduleService implements I_ScheduleService {
     @Override
     public ScheduleResponse selectSchedule(long id) {
         Schedule schedule = scheduleRepository.findById(id)
-                .orElseThrow();
+                .orElseThrow(() -> new EscaException(ScheduleExceptions.NOT_FOUND_SCHEDULE));
         return new ScheduleResponse(schedule);
     }
 
@@ -39,14 +40,14 @@ public class ScheduleService implements I_ScheduleService {
     public ScheduleResponse addSchedule(ScheduleRequest request) {
         Schedule schedule = new Schedule(request.getTitle(), request.getTag(), request.getContent(), request.getStartDate(), request.getStartDate());
         Schedule savedSchedule = scheduleRepository.save(schedule);
-        return new ScheduleResponse(schedule);
+        return new ScheduleResponse(savedSchedule);
     }
 
     @Transactional
     @Override
     public ScheduleResponse updateSchedule(long id, ScheduleRequest request) {
         Schedule schedule = scheduleRepository.findById(id)
-                .orElseThrow();;
+                .orElseThrow(() -> new EscaException(ScheduleExceptions.NOT_FOUND_SCHEDULE));
         schedule.update(request.getTitle(), request.getTag(), request.getContent(), request.getStartDate(), request.getEndDate());
         return new ScheduleResponse(schedule);
     }
@@ -55,7 +56,7 @@ public class ScheduleService implements I_ScheduleService {
     @Override
     public void deleteSchedule(long id) {
         scheduleRepository.findById(id)
-                .orElseThrow();
+                .orElseThrow(() -> new EscaException(ScheduleExceptions.NOT_FOUND_SCHEDULE));
         scheduleRepository.deleteById(id);
     }
 }

--- a/escahp/src/main/java/com/esca/escahp/schedule/dto/ScheduleRequest.java
+++ b/escahp/src/main/java/com/esca/escahp/schedule/dto/ScheduleRequest.java
@@ -1,0 +1,29 @@
+package com.esca.escahp.schedule.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleRequest {
+
+    @ApiModelProperty(value = "일정 제목")
+    private String title;
+
+    @ApiModelProperty(value = "일정 태그")
+    private String tag;
+
+    @ApiModelProperty(value = "일정 내용")
+    private String content;
+
+    @ApiModelProperty(value = "일정 시작 일자")
+    private LocalDateTime startDate;
+
+    @ApiModelProperty(value = "일정 종료 일자")
+    private LocalDateTime endDate;
+}

--- a/escahp/src/main/java/com/esca/escahp/schedule/dto/ScheduleResponse.java
+++ b/escahp/src/main/java/com/esca/escahp/schedule/dto/ScheduleResponse.java
@@ -1,5 +1,6 @@
 package com.esca.escahp.schedule.dto;
 
+import com.esca.escahp.schedule.entity.Schedule;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -37,4 +38,14 @@ public class ScheduleResponse {
 
     @ApiModelProperty(value = "수정일자")
     private LocalDateTime updatedAt;
+
+    public ScheduleResponse(Schedule schedule) {
+        this.id = schedule.getId();
+        this.tag = schedule.getTag();
+        this.content = schedule.getContent();
+        this.startDate = schedule.getStartDate();
+        this.endDate = schedule.getEndDate();
+        this.createdAt = schedule.getCreatedAt();
+        this.updatedAt = schedule.getUpdatedAt();
+    }
 }

--- a/escahp/src/main/java/com/esca/escahp/schedule/dto/ScheduleResponse.java
+++ b/escahp/src/main/java/com/esca/escahp/schedule/dto/ScheduleResponse.java
@@ -1,0 +1,40 @@
+package com.esca.escahp.schedule.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Id;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleResponse {
+    @Id
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ApiModelProperty(value = "일정 제목")
+    private String title;
+
+    @ApiModelProperty(value = "일정 태그")
+    private String tag;
+
+    @ApiModelProperty(value = "일정 내용")
+    private String content;
+
+    @ApiModelProperty(value = "일정 시작 일자")
+    private LocalDateTime startDate;
+
+    @ApiModelProperty(value = "일정 종료 일자")
+    private LocalDateTime endDate;
+
+    @ApiModelProperty(value = "작성일자")
+    private LocalDateTime createdAt;
+
+    @ApiModelProperty(value = "수정일자")
+    private LocalDateTime updatedAt;
+}

--- a/escahp/src/main/java/com/esca/escahp/schedule/entity/Schedule.java
+++ b/escahp/src/main/java/com/esca/escahp/schedule/entity/Schedule.java
@@ -4,8 +4,6 @@ import java.time.LocalDateTime;
 
 import javax.persistence.*;
 
-import org.hibernate.annotations.CreationTimestamp;
-
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -18,7 +16,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 @Entity
 public class Schedule {
     @Id
-    @Column(name = "id", nullable = false)
+    @GeneratedValue
     private Long id;
 
     @Column(nullable = false)
@@ -43,4 +41,20 @@ public class Schedule {
     @Column
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public Schedule(String title, String tag, String content, LocalDateTime startDate, LocalDateTime endDate){
+        this.title = title;
+        this.tag = tag;
+        this.content = content;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public void update(String title, String tag, String content, LocalDateTime startDate, LocalDateTime endDate) {
+        this.title = title;
+        this.tag = tag;
+        this.content = content;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
 }

--- a/escahp/src/main/java/com/esca/escahp/schedule/entity/Schedule.java
+++ b/escahp/src/main/java/com/esca/escahp/schedule/entity/Schedule.java
@@ -9,6 +9,8 @@ import org.hibernate.annotations.CreationTimestamp;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
 @Setter
@@ -33,4 +35,12 @@ public class Schedule {
 
     @Column(nullable = false)
     private LocalDateTime endDate;
+
+    @Column(nullable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 }

--- a/escahp/src/main/java/com/esca/escahp/schedule/exceptions/ScheduleExceptions.java
+++ b/escahp/src/main/java/com/esca/escahp/schedule/exceptions/ScheduleExceptions.java
@@ -1,0 +1,26 @@
+package com.esca.escahp.schedule.exceptions;
+
+import com.esca.escahp.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public enum ScheduleExceptions implements CustomException {
+    NOT_FOUND_SCHEDULE("해당 연간일정을 찾을 수 없습니다", HttpStatus.NOT_FOUND.value());
+
+    private final String message;
+    private final int status;
+
+    ScheduleExceptions(String message, int status) {
+        this.message = message;
+        this.status = status;
+    }
+
+    @Override
+    public String getMessage() {
+        return null;
+    }
+
+    @Override
+    public int getStatus() {
+        return 0;
+    }
+}


### PR DESCRIPTION
## 작업 내용

> 작업 내용에 대한 summary를 작성해주세요

- 연간일정 엔티티 일부 수정
  - 생성일자, 수정일자 추가
  - id 자동생성 어노테이션 추가
- 연간일정 api 작성
  - 전체 일정 조회
  - 특정 일정 조회
  - 일정 등록
  - 일정 수정
  - 일정 삭제

## 겪은 문제, 궁금한 점

> 작업을 진행하며 겪었던 이슈 중 공유하고 싶은 부분이 있다면 작성해주세요.

- 현재 전체 조회와 특정 일정 조회 api만 있는데 연도별로 가져오는 것도 필요할지? 피그마 반영되는 거 보고 진행해야할듯

## 참고 링크

> 작업하시면서 참고한 링크가 있거나 리뷰할 때 확인해야 하는 링크가 있다면 작성해주세요

- N/A

## 기타 사항

> 그 외 기타 사항이 있다면 작성해주세요

- N/A
